### PR TITLE
feat: use errors for contract size reduction, gas optimization & better error handling

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -6,3 +6,5 @@ openzeppelin-contracts/=lib/openzeppelin-contracts/
 openzeppelin/=lib/openzeppelin-contracts/contracts/
 @account-abstraction/=lib/account-abstraction/
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@libraries/=src/libraries/
+@base/=src/base/

--- a/src/base/MynaWallet.sol
+++ b/src/base/MynaWallet.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@account-abstraction/contracts/core/BaseAccount.sol";
-import {SolRsaVerify} from "../libraries/RsaVerify.sol";
+import {SolRsaVerify} from "@libraries/RsaVerify.sol";
+import {Errors} from "@libraries/Errors.sol";
 
 /// @title MynaWallet
 /// @author a42x
@@ -74,7 +75,7 @@ contract MynaWallet is BaseAccount, UUPSUpgradeable, Initializable {
      */
     function executeBatch(address[] calldata dest, bytes[] calldata func) external {
         _requireFromEntryPoint();
-        require(dest.length == func.length, "MynaWallet: wrong array lengths");
+        if (dest.length != func.length) revert Errors.InvalidArrayLength(dest.length, func.length);
         for (uint256 i = 0; i < dest.length; i++) {
             _call(dest[i], 0, func[i]);
         }
@@ -128,7 +129,7 @@ contract MynaWallet is BaseAccount, UUPSUpgradeable, Initializable {
      */
     function _requireFromSelf() internal view {
         //directly through the account
-        require(msg.sender == address(this), "MynaWallet: not from account");
+        if (msg.sender != address(this)) revert Errors.NotFromAccount(msg.sender);
     }
 
     /**

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.19;
+
+library Errors {
+    error InvalidArrayLength(uint256 destLength, uint256 funcLength);
+    error NotFromAccount(address sender);
+}


### PR DESCRIPTION
# Description

Modified to use `error` instead of using `require` because it reduces contract code size so that it reduces contract deployment gas cost as well.

`error` also enables us to return custom error objects with values even though `require` can only return static messages. This will improve the error-handling process.

It's easy to foresee that the contract size will increase as various implementations are added in the future. Additionally, by separating out errors as a library, the code's readability will also improve.


## `error`: 8.582kb
<img width="335" alt="Screenshot 2023-08-23 at 0 11 22" src="https://github.com/MynaWallet/contracts/assets/1129345/f6aac27c-7308-4746-9e6e-e798197c5f5f">

##  `require`: 8.675kb
<img width="367" alt="Screenshot 2023-08-23 at 0 11 31" src="https://github.com/MynaWallet/contracts/assets/1129345/5e1061e3-75b4-4a25-8f75-ecbc64693878">


